### PR TITLE
Ignore Jekyll temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ _site/
 
 # mypy
 .mypy_cache/
+
+.sass-cache
+.jekyll-metadata
+


### PR DESCRIPTION
This commit ignores the `.sass-cache` and `.jekyll-metadata` folders that
Jekyll generates when compiling.