### PR TITLE
Use guard instead of jekyll serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ clean:
 	python scripts/clean.py
 
 serve:
-	bundle exec jekyll serve
+	bundle exec guard


### PR DESCRIPTION
Using `guard` (https://github.com/guard/guard) to start Jekyll instead
of `jekyll serve` gives two benefits:

1. It will auto-restart Jekyll when the `_config.yml` file changes in
   addition to normal file changes.
2. It starts the livereload server which will autoreload the browser
   whenever jekyll rebuilds the site (you'll have to install
   https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en
   first).