### PR TITLE
Juniper interactive code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ textbook_repo_name       : "jupyter-book"  # The name of the repository on the w
 textbook_repo_branch     : "master"  # The branch on which your textbook is hosted.
 use_jupyterlab           : false  # If 'true', interact links will use JupyterLab as the interface
 interact_text            : "Interact"  # The text that interact buttons will contain.
+use_juniper_button       : true  # If 'true', display a button to allow in-page running code cells with Juniper
 
 # Site settings (only modify if you know what you're doing)
 defaults:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -60,7 +60,9 @@
   <!-- Update interact links w/ REST param, is defined in includes so we can use templates -->
   {% include interact-update.html %}
 
-  <!-- Include Juniper for interactive code -->
+  <!-- Include Juniper for interactive code if it's enabled -->
+  {% if site.use_juniper_button %}
+  {% include juniper.html %}
   <script src="https://unpkg.com/juniper-js@0.0.4/dist/juniper.min.js"></script>
-
+  {% endif %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,4 +59,8 @@
 
   <!-- Update interact links w/ REST param, is defined in includes so we can use templates -->
   {% include interact-update.html %}
+
+  <!-- Include Juniper for interactive code -->
+  <script src="https://unpkg.com/juniper-js@0.0.4/dist/juniper.min.js"></script>
+
 </head>

--- a/_includes/interact.html
+++ b/_includes/interact.html
@@ -14,5 +14,6 @@
     {% endif %}
     <div class="buttons">
         <a class="interact-button" href="{{ site.hub_url }}/{{ interact_url }}">{{ site.interact_text }}</a>
+        {% if site.use_juniper_button %}<button id="juniper-button" class="interact-button">Juniper</button>{% endif %}
     </div>
 {% endif %}

--- a/_includes/juniper.html
+++ b/_includes/juniper.html
@@ -1,0 +1,52 @@
+<script>
+/**
+ * Add attributes to Juniper blocks
+ */
+
+const initJuniper = () => {
+    
+    const addJuniperToCodeCells = () => {
+        // If Juniper hasn't loaded, wait a bit and try again. This
+        // happens because we load ClipboardJS asynchronously.
+        if (window.Juniper === undefined) {
+        setTimeout(addJuniperToCodeCells, 250)
+        return
+        }
+
+        // If we already detect a Juniper cell, don't re-run
+        if (document.querySelectorAll('div.juniper-cell').length > 0) {
+            return;
+        }
+
+        const codeCells = document.querySelectorAll('.input_area pre')
+        codeCells.forEach((codeCell, index) => {
+        const id = codeCellId(index)
+        codeCell.setAttribute('data-executable', '')
+        });
+
+        new Juniper({
+        repo: '{{ site.textbook_repo_org }}/{{ site.textbook_repo_name }}',
+        branch: '{{ site.textbook_repo_branch }}'
+        });
+
+        // Remove copy buttons since they won't work anymore
+        const copyButtons = document.querySelectorAll('.copybtn')
+        copyButtons.forEach((copyButton, index) => {
+        copyButton.remove();
+        });
+    }
+
+    const getJuniper = () => document.getElementById('juniper-button')
+    const juniperButton = getJuniper();
+    if (juniperButton === null) {
+    setTimeout(initJuniper, 250)
+    return
+    };
+
+    juniperButton.addEventListener('click', addJuniperToCodeCells);
+}
+
+// Initialize Juniper
+runWhenDOMLoaded(initJuniper)
+document.addEventListener('turbolinks:load', initJuniper)
+</script>

--- a/_sass/components/_components.codemirror.scss
+++ b/_sass/components/_components.codemirror.scss
@@ -1,0 +1,25 @@
+pre.CodeMirror-line {
+    padding: 0;
+    margin-bottom: 0px;
+    border: none;
+}
+
+div.CodeMirror {
+    padding: .5em 1em 1em;
+}
+
+.juniper-output {
+    background: #eee;
+    color: #000;
+    padding: .5em;
+    white-space: pre-wrap;
+    margin-bottom: 1em;
+}
+
+pre.CodeMirror-line span {
+    padding: 0px.2em 0px .2em;
+}
+
+.juniper-button {
+    z-index: 999;
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -107,6 +107,7 @@ $hamburger-types: (arrowalt);
 @import 'components/components.sidebar-toggle';
 @import 'components/components.interact-button';
 @import 'components/components.textbook__sidebar-right';
+@import 'components/components.codemirror';
 
 // UTILITIES
 @import 'inuitcss/utilities/utilities.clearfix';

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -177,3 +177,29 @@ const addCopyButtonToCodeCells = () => {
 
 runWhenDOMLoaded(addCopyButtonToCodeCells)
 document.addEventListener('turbolinks:load', addCopyButtonToCodeCells)
+
+
+/**
+ * [7] Add attributes to Juniper blocks
+ */
+const addJuniperToCodeCells = () => {
+  // If Juniper hasn't loaded, wait a bit and try again. This
+  // happens because we load ClipboardJS asynchronously.
+  if (window.Juniper === undefined) {
+    setTimeout(addJuniperToCodeCells, 250)
+    return
+  }
+
+  const codeCells = document.querySelectorAll('.input_area pre')
+  codeCells.forEach((codeCell, index) => {
+    const id = codeCellId(index)
+    codeCell.setAttribute('data-executable', '')
+  });
+
+  new Juniper({
+    repo: 'binder-examples/jupyterlab'
+  });
+}
+
+runWhenDOMLoaded(addJuniperToCodeCells)
+document.addEventListener('turbolinks:load', addJuniperToCodeCells)

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -12,6 +12,7 @@ const togglerId = 'js-sidebar-toggle'
 const textbookId = 'js-textbook'
 const togglerActiveClass = 'is-active'
 const textbookActiveClass = 'js-show-sidebar'
+const juniperId = 'juniper-button'
 
 const mathRenderedClass = 'js-mathjax-rendered'
 
@@ -197,9 +198,26 @@ const addJuniperToCodeCells = () => {
   });
 
   new Juniper({
-    repo: 'binder-examples/jupyterlab'
+    repo: 'data-8/textbook'
+  });
+
+  // Remove copy buttons since they won't work anymore
+  const copyButtons = document.querySelectorAll('.copybtn')
+  copyButtons.forEach((copyButton, index) => {
+    copyButton.remove();
   });
 }
 
-runWhenDOMLoaded(addJuniperToCodeCells)
-document.addEventListener('turbolinks:load', addJuniperToCodeCells)
+const initJuniper = () => {
+  const getJuniper = () => document.getElementById('juniper-button')
+  const juniperButton = getJuniper();
+  if (juniperButton === null) {
+    setTimeout(initJuniper, 250)
+    return
+  };
+  juniperButton.addEventListener('click', addJuniperToCodeCells);
+}
+
+{% if site.use_juniper_button %}
+initJuniper();
+{% endif %}


### PR DESCRIPTION
I recently came across this nifty extension of Thebelab: https://github.com/ines/juniper

It's a lightweight Javascript package that connects to a Binder kernel and uses CodeMirror to make code cells editable / runnable.

This PR is a first-pass at enabling this functionality in Jupyter-book. This lets you do stuff like this:


![juniper](https://user-images.githubusercontent.com/1839645/46966450-a9dcea80-d062-11e8-855b-5ce0ed7fdaee.gif)


Any feedback or pushes directly to this branch is encouraged!

## To Do
* Stabilize the Binder handshake
* Clean up the CSS
* Figure out if this is the right usage pattern (I think this feature should be "beta" for a while)

cc @ines if they have thoughts